### PR TITLE
parallelize process wfmash, wfmash can be run exclusively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,5 @@ jobs:
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --smoothxg consensus_spec 10,100,1000
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --vcf_spec "gi|568815561:#,gi|568815567:#"
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --smoothxg_write_maf
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --wfmash_chunks 2
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --wfmash_only

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update \
                           procps \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
+COPY bin/split_approx_mappings_in_chunks.py /
+
 # Install miniconda
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \

--- a/README.md
+++ b/README.md
@@ -98,4 +98,10 @@ You can cite the `nf-core` publication as follows:
 
 In addition, references of tools and data used in this pipeline are as follows:
 
+> **ODGI: understanding pangenome graphs.**
+>
+> Andrea Guarracino, Simon Heumos, Sven Nahnsen, Pjotr Prins & Erik Garrison.
+>
+> _bioRxiv_ 2021 Nov 11 doi: [10.1101/2021.11.10.467921](https://doi.org/10.1101/2021.11.10.467921).
+
 <!-- TODO nf-core: Add bibliography of tools and data used in your pipeline -->

--- a/bin/split_approx_mappings_in_chunks.py
+++ b/bin/split_approx_mappings_in_chunks.py
@@ -1,0 +1,55 @@
+# Usage
+# Run:
+#   python3 split_approx_mappings_in_chunks.py approximate_mappings.paf 4
+# It will generate the following files:
+#   approximate_mappings.paf.chunk_0.paf
+#   approximate_mappings.paf.chunk_1.paf
+#   approximate_mappings.paf.chunk_2.paf
+#   approximate_mappings.paf.chunk_3.paf
+
+import sys
+
+# The script that takes the approximate mappings, weighs each mapping by computing its length * (1 - estimated identity),
+# then creates N new files where the mapping sets have a similar sum of weights.
+
+def split_chunks(l, n):
+    result = [[] for i in range(n)]
+    sums = [0] * n
+    i = 0
+    for e in l:
+        result[i].append(e)
+        sums[i] += e[1]
+        i = sums.index(min(sums))
+    return result
+
+
+if __name__ == '__main__':
+    path_approx_mappings = sys.argv[1]
+    num_of_chunks = int(sys.argv[2])
+
+    rank_to_mapping_dict = {}
+    mapping_list = []
+
+    with open(path_approx_mappings) as f:
+        for rank, line in enumerate(f):
+            # We could avoid keeping everything in memory by reading the file again later
+            rank_to_mapping_dict[rank] = line
+
+            _, _, query_start, query_end, _, _, _, target_start, target_end, _, _, _, estimated_identity = line.strip().split('\t')
+
+            num_mapped_bases = max(int(query_end) - int(query_start), int(target_end) - int(target_start))
+            estimated_identity = float(estimated_identity.split('id:f:')[1]) / 100.0
+
+            # High divergence makes alignment more difficult
+            weight = num_mapped_bases * (1 - estimated_identity)
+
+            mapping_list.append((rank, weight))
+
+	# Chunk the tuples by looking at their weigths
+    chunk_list = split_chunks(mapping_list, num_of_chunks)
+
+	# Collect the ranks from the tuples to generate balanced chunks
+    for num_chunk, element_list in enumerate(chunk_list):
+        with open(path_approx_mappings + f'.chunk_{num_chunk}.paf', 'w') as fw:
+            for rank, _ in element_list:
+                fw.write(rank_to_mapping_dict[rank])

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,8 @@ params {
   wfmash_merge_segments = false
   wfmash_no_splits = false
   wfmash_exclude_delim = false
+  wfmash_chunks = 1
+  wfmash_only = false
 
   // Seqwish options
   seqwish_min_match_length = 47

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -84,6 +84,15 @@
                     "type": "string",
                     "description": "skip mappings between sequences with the same name prefix before the given delimiter character",
                     "fa_icon": "fas fa-align-center"
+                },
+                "wfmash_chunks": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "The number of files to generate from the approximate wfmash mappings to scale across a whole cluster. It is recommended to set this to the number of available nodes. If only one machine is available, leave it at 1."
+                },
+                "wfmash_only": {
+                    "type": "boolean",
+                    "description": "If this parameter is set, only the wfmash alignment step of the pipeline is executed. This option is offered for users who want to use wfmash on a cluster."
                 }
             }
         },
@@ -146,7 +155,7 @@
                 },
                 "smoothxg_block_ratio_min": {
                     "type": "number",
-                    "default": 0.0,
+                    "default": 0,
                     "description": "minimum small / large length ratio to cluster in a block"
                 },
                 "smoothxg_block_id_min": {


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pangenome/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/pangenome _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).

This PR parallelizes the `wfmash` process so it can scale on a whole cluster. This is possible with the https://github.com/ekg/wfmash/blob/master/scripts/split_approx_mappings_in_chunks.py script thanks to @AndreaGuarracino!

- [x] Added process wfmashMap which only runs the approximate mapping step of `wfmash`.
- [x] Added process splitApproxMappingsInChunks which divides the approximate .paf into chunks of equal problem size.
- [x] Added process wfmashAlign which performs the base-level alignment step of `wfmash` for each chunk in parallel process submissions.
- [x] The `--wfmash_only` parameter stops the pipeline after the `wfmash` step. This makes it possible for user to scale only `wfmash` across a whole cluster.
- [x] Updated tests, JSON schemas, etc. 